### PR TITLE
wiki: hardware: fix additional pages linking

### DIFF
--- a/wiki/hardware/JH7110.md
+++ b/wiki/hardware/JH7110.md
@@ -26,13 +26,8 @@ External Sites:
 
 Additional pages:
 
-{% for testpage in site.pages %}
-{% assign dirs = testpage.dir | split : "/"  %}
-{% for dc in dirs %}
-{% if dc == "JH7110" %}
-{% if testpage.url != page.url %}
-* [{{testpage.title}}]({{page.url}})
-{% endif %}
-{% endif %}
-{% endfor %}
+{% for page in site.pages %}
+  {% if page.folder == 'jh7110' %}
+* [{{ page.title }}]({{page.url}})
+  {% endif %}
 {% endfor %}

--- a/wiki/hardware/JH7110/boards.md
+++ b/wiki/hardware/JH7110/boards.md
@@ -1,3 +1,8 @@
+---
+title: StarFive JH7110 Based Boards
+folder: jh7110
+---
+
 # StarFive JH7110 Based Boards
 
 This is as a complete of a list as we can make it. Please limit these to boards that are available, frequently there are limited run dev boards, or products that never entered production. We typically don't include those.

--- a/wiki/hardware/K1.md
+++ b/wiki/hardware/K1.md
@@ -27,13 +27,8 @@ External Sites:
 
 Additional pages:
 
-{% for testpage in site.pages %}
-{% assign dirs = testpage.dir | split : "/"  %}
-{% for dc in dirs %}
-{% if dc == "K1" %}
-{% if testpage.url != page.url %}
-* [{{testpage.title}}]({{page.url}})
-{% endif %}
-{% endif %}
-{% endfor %}
+{% for page in site.pages %}
+  {% if page.folder == 'k1' %}
+* [{{ page.title }}]({{page.url}})
+  {% endif %}
 {% endfor %}

--- a/wiki/hardware/K1/boards.md
+++ b/wiki/hardware/K1/boards.md
@@ -1,3 +1,8 @@
+---
+title: SpacemIT K1 based boards
+folder: k1
+---
+
 # SpacemIT K1 based boards
 
 This is as a complete of a list as we can make it. Please limit these to boards that are available, frequently there are limited run dev boards, or products that never entered production. We typically don't include those.

--- a/wiki/hardware/TH1520.md
+++ b/wiki/hardware/TH1520.md
@@ -1,3 +1,8 @@
+---
+title: Alibaba T-Head TH1520 SoC
+folder: hardware
+---
+
 # Alibaba T-Head TH1520 SoC
 
 The TH1520 is a SoC used on several [boards](/wiki/hardware/TH1520/boards.html). It has the following main features:
@@ -28,13 +33,8 @@ Reference Documentation:
 
 Additional pages:
 
-{% for testpage in site.pages %}
-{% assign dirs = testpage.dir | split : "/"  %}
-{% for dc in dirs %}
-{% if dc == "TH1520" %}
-{% if testpage.url != page.url %}
-* [{{testpage.title}}]({{page.url}})
-{% endif %}
-{% endif %}
-{% endfor %}
+{% for page in site.pages %}
+  {% if page.folder == 'th1520' %}
+* [{{ page.title }}]({{page.url}})
+  {% endif %}
 {% endfor %}

--- a/wiki/hardware/TH1520/boards.md
+++ b/wiki/hardware/TH1520/boards.md
@@ -1,3 +1,8 @@
+---
+title: Alibaba T-Head TH1520 based boards
+folder: th1520
+---
+
 # Alibaba T-Head TH1520 based boards
 
 This is as a complete of a list as we can make it. Please limit these to boards that are available, frequently there are limited run dev boards, or products that never entered production. We typically don't include those.

--- a/wiki/hardware/TH1520/lpi4-bsp.md
+++ b/wiki/hardware/TH1520/lpi4-bsp.md
@@ -1,3 +1,8 @@
+---
+title: Updating the BSP on the eMMC of the Sipeed Lichee Pi 4A
+folder: th1520
+---
+
 # Updating the BSP on the eMMC of the Sipeed Lichee Pi 4A
 
 The BSP (or Board Support Package) is the OS shipped by Sipeed for the Lichee Pi 4A

--- a/wiki/hardware/TH1520/video.md
+++ b/wiki/hardware/TH1520/video.md
@@ -1,3 +1,8 @@
+---
+title: TH1520 Video Subsystem
+folder: th1520
+---
+
 # TH1520 Video Subsystem
 
 # Sources


### PR DESCRIPTION
the liquid code for dynamically adding "additional pages" is not working as expected as it self links the file name instead of the files inside the directory. this aims to fix that by adding front matter to the pages.

fixes #3 